### PR TITLE
make buildVersions extensible; cleanup unused spec

### DIFF
--- a/src/buildVersions/BuildVersions.ts
+++ b/src/buildVersions/BuildVersions.ts
@@ -16,10 +16,10 @@ export class BuildVersions {
 
   constructor(globalConfig: IGlobalConfig) {
     this.globalConfig = globalConfig
-    if (!globalConfig.buildVersionsRepo) {
-      throw new Error('buildVersionsRepo is required')
+    if (!globalConfig.buildVersions?.gitRepo) {
+      throw new Error('buildVersions.gitRepo is required')
     }
-    this.gitRepo = new GitRepo(globalConfig, globalConfig.buildVersionsRepo)
+    this.gitRepo = new GitRepo(globalConfig, globalConfig.buildVersions.gitRepo)
   }
 
   public async initAsync() {

--- a/src/spec/base/ITrigger.ts
+++ b/src/spec/base/ITrigger.ts
@@ -1,4 +1,11 @@
 export interface ITrigger {
   trigger: boolean | undefined;
   triggerBranch: string | undefined;
+  triggerAction: ITriggerAction | undefined;
+}
+
+export interface ITriggerAction {
+  clone: boolean | undefined;
+  cloneRef: string | undefined;
+  script: string | string[] | undefined;
 }

--- a/src/spec/buildVersions/IBuildVersions.ts
+++ b/src/spec/buildVersions/IBuildVersions.ts
@@ -12,7 +12,7 @@ export interface IRepoData {
   tagPrefixMap: ITagPrefixMap;
 }
 
-export type ICommitVersionMap = Record<string, string>         // branch      : version
+export type ICommitVersionMap = Record<string, string>     // branch      : version
 
 export type ITagVersionMap = Record<string, string[]>      // releaseType : versions
 

--- a/src/spec/global/IGlobalConfig.ts
+++ b/src/spec/global/IGlobalConfig.ts
@@ -1,6 +1,6 @@
 export interface IGlobalConfig {
   artifactRepoMap: Record<string, any> | undefined;
-  buildVersionsRepo: IGitConnectionRepo | undefined;
+  buildVersions: IBuildVersionsGitRepo | undefined;
   environmentMap: Record<string, any> | undefined;
   gitConnectionMap: Record<string, IGitConnection> | undefined;
 }
@@ -15,6 +15,10 @@ export interface IGitConnection {
   remotePasswordEnvVar: string;
   sshKeyFile: string;
   sshKeyFileEnvVar: string;
+}
+
+interface IBuildVersionsGitRepo {
+  gitRepo: IGitConnectionRepo;
 }
 
 export interface IGitConnectionRepo {

--- a/src/spec/method/IFileMethod.ts
+++ b/src/spec/method/IFileMethod.ts
@@ -1,8 +1,0 @@
-interface IFileUpdateMethod {
-  orphanBranch: IFile | undefined;
-}
-
-interface IFile {
-  branch: string | undefined;
-  fileNameTemplate: string | undefined;
-}

--- a/src/spec/method/IOrphanBranchMethod.ts
+++ b/src/spec/method/IOrphanBranchMethod.ts
@@ -1,8 +1,0 @@
-interface IOrphanBranchUpdateMethod {
-  orphanBranch: IOrphanBranch | undefined;
-}
-
-interface IOrphanBranch {
-  branchNameTemplate: string | undefined;
-  imageVersionsFile: string | undefined;
-}

--- a/src/spec/provider/IGitLabProvider.ts
+++ b/src/spec/provider/IGitLabProvider.ts
@@ -1,7 +1,0 @@
-interface IGitLabCiProvider {
-  gitLab: IGitLab | undefined;
-}
-
-interface IGitLab {
-  ciFile: string | undefined;
-}

--- a/src/spec/repo/ICommon.ts
+++ b/src/spec/repo/ICommon.ts
@@ -1,12 +1,12 @@
 import {IArtifacts, IArtifactType} from '../base/IArtifacts'
 import {IEvent, IEventRegex} from '../base/IEvent'
+import {ITrigger} from '../base/ITrigger'
 
-export interface ICommon extends IArtifacts {
+type ICommonBase = IArtifacts & ITrigger;
+
+export interface ICommon extends ICommonBase {
   artifactPublishEvents: IArtifactPublishEvents[] | undefined;
-  ciProvider: IGitLabCiProvider | undefined;
-  defaultBranch: string | undefined;
   name: string | undefined;
-  updateMethod: IFileUpdateMethod | IOrphanBranchUpdateMethod | undefined;
 }
 
 type IArtifactPublishEventsBase = IArtifactType & IEvent & IEventRegex;

--- a/src/spec/schema.json
+++ b/src/spec/schema.json
@@ -106,12 +106,6 @@
                 "artifacts": {
                     "$ref": "#/definitions/Record<string,string[]>"
                 },
-                "ciProvider": {
-                    "$ref": "#/definitions/IGitLabCiProvider"
-                },
-                "defaultBranch": {
-                    "type": "string"
-                },
                 "dependencies": {
                     "allOf": [
                         {
@@ -134,15 +128,14 @@
                 "name": {
                     "type": "string"
                 },
-                "updateMethod": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/IFileUpdateMethod"
-                        },
-                        {
-                            "$ref": "#/definitions/IOrphanBranchUpdateMethod"
-                        }
-                    ]
+                "trigger": {
+                    "type": "boolean"
+                },
+                "triggerAction": {
+                    "$ref": "#/definitions/ITriggerAction"
+                },
+                "triggerBranch": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -154,6 +147,14 @@
                 },
                 "repos": {
                     "$ref": "#/definitions/Record<string,IRepoData>"
+                }
+            },
+            "type": "object"
+        },
+        "IBuildVersionsGitRepo": {
+            "properties": {
+                "gitRepo": {
+                    "$ref": "#/definitions/IGitConnectionRepo"
                 }
             },
             "type": "object"
@@ -172,24 +173,17 @@
                 "artifacts": {
                     "$ref": "#/definitions/Record<string,string[]>"
                 },
-                "ciProvider": {
-                    "$ref": "#/definitions/IGitLabCiProvider"
-                },
-                "defaultBranch": {
-                    "type": "string"
-                },
                 "name": {
                     "type": "string"
                 },
-                "updateMethod": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/IFileUpdateMethod"
-                        },
-                        {
-                            "$ref": "#/definitions/IOrphanBranchUpdateMethod"
-                        }
-                    ]
+                "trigger": {
+                    "type": "boolean"
+                },
+                "triggerAction": {
+                    "$ref": "#/definitions/ITriggerAction"
+                },
+                "triggerBranch": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -204,12 +198,6 @@
                 },
                 "artifacts": {
                     "$ref": "#/definitions/Record<string,string[]>"
-                },
-                "ciProvider": {
-                    "$ref": "#/definitions/IGitLabCiProvider"
-                },
-                "defaultBranch": {
-                    "type": "string"
                 },
                 "deploymentMap": {
                     "$ref": "#/definitions/Record<string,IDeployment>"
@@ -233,15 +221,14 @@
                     },
                     "type": "array"
                 },
-                "updateMethod": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/IFileUpdateMethod"
-                        },
-                        {
-                            "$ref": "#/definitions/IOrphanBranchUpdateMethod"
-                        }
-                    ]
+                "trigger": {
+                    "type": "boolean"
+                },
+                "triggerAction": {
+                    "$ref": "#/definitions/ITriggerAction"
+                },
+                "triggerBranch": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -295,6 +282,9 @@
                 "trigger": {
                     "type": "boolean"
                 },
+                "triggerAction": {
+                    "$ref": "#/definitions/ITriggerAction"
+                },
                 "triggerBranch": {
                     "type": "string"
                 }
@@ -347,25 +337,6 @@
             },
             "type": "object"
         },
-        "IFile": {
-            "properties": {
-                "branch": {
-                    "type": "string"
-                },
-                "fileNameTemplate": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "IFileUpdateMethod": {
-            "properties": {
-                "orphanBranch": {
-                    "$ref": "#/definitions/IFile"
-                }
-            },
-            "type": "object"
-        },
         "IGitConnection": {
             "properties": {
                 "authorEmail": {
@@ -412,54 +383,19 @@
             },
             "type": "object"
         },
-        "IGitLab": {
-            "properties": {
-                "ciFile": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "IGitLabCiProvider": {
-            "properties": {
-                "gitLab": {
-                    "$ref": "#/definitions/IGitLab"
-                }
-            },
-            "type": "object"
-        },
         "IGlobalConfig": {
             "properties": {
                 "artifactRepoMap": {
                     "$ref": "#/definitions/Record<string,any>"
                 },
-                "buildVersionsRepo": {
-                    "$ref": "#/definitions/IGitConnectionRepo"
+                "buildVersions": {
+                    "$ref": "#/definitions/IBuildVersionsGitRepo"
                 },
                 "environmentMap": {
                     "$ref": "#/definitions/Record<string,any>"
                 },
                 "gitConnectionMap": {
                     "$ref": "#/definitions/Record<string,IGitConnection>"
-                }
-            },
-            "type": "object"
-        },
-        "IOrphanBranch": {
-            "properties": {
-                "branchNameTemplate": {
-                    "type": "string"
-                },
-                "imageVersionsFile": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "IOrphanBranchUpdateMethod": {
-            "properties": {
-                "orphanBranch": {
-                    "$ref": "#/definitions/IOrphanBranch"
                 }
             },
             "type": "object"
@@ -475,12 +411,6 @@
                 "artifacts": {
                     "$ref": "#/definitions/Record<string,string[]>"
                 },
-                "ciProvider": {
-                    "$ref": "#/definitions/IGitLabCiProvider"
-                },
-                "defaultBranch": {
-                    "type": "string"
-                },
                 "gitTagDisable": {
                     "type": "boolean"
                 },
@@ -493,15 +423,14 @@
                 "promotionMap": {
                     "$ref": "#/definitions/Record<string,IPromotion>"
                 },
-                "updateMethod": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/IFileUpdateMethod"
-                        },
-                        {
-                            "$ref": "#/definitions/IOrphanBranchUpdateMethod"
-                        }
-                    ]
+                "trigger": {
+                    "type": "boolean"
+                },
+                "triggerAction": {
+                    "$ref": "#/definitions/ITriggerAction"
+                },
+                "triggerBranch": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -575,8 +504,35 @@
                 "trigger": {
                     "type": "boolean"
                 },
+                "triggerAction": {
+                    "$ref": "#/definitions/ITriggerAction"
+                },
                 "triggerBranch": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ITriggerAction": {
+            "properties": {
+                "clone": {
+                    "type": "boolean"
+                },
+                "cloneRef": {
+                    "type": "string"
+                },
+                "script": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 }
             },
             "type": "object"

--- a/test/config/data/command/global.yaml
+++ b/test/config/data/command/global.yaml
@@ -1,6 +1,7 @@
-buildVersionsRepo:
-  gitConnectionKey: gitHub
-  path: build-versions
+buildVersions:
+  gitRepo:
+    gitConnectionKey: gitHub
+    path: build-versions
 gitConnectionMap:
   gitHub:
     authorEmail: test

--- a/test/config/data/global/global-expected.yaml
+++ b/test/config/data/global/global-expected.yaml
@@ -1,9 +1,10 @@
 artifactRepoMap:
   dev: dev
   stage: stage
-buildVersionsRepo:
-  gitConnectionKey: gitHub
-  path: build-versions
+buildVersions:
+  gitRepo:
+    gitConnectionKey: gitHub
+    path: build-versions
 environmentMap:
   dev: dev
   stage: stage

--- a/test/config/data/global/global2.yaml
+++ b/test/config/data/global/global2.yaml
@@ -1,8 +1,9 @@
 artifactRepoMap:
   stage: stage
-buildVersionsRepo:
-  gitConnectionKey: gitHub
-  path: build-versions
+buildVersions:
+  gitRepo:
+    gitConnectionKey: gitHub
+    path: build-versions
 environmentMap:
   stage: stage
 gitConnectionMap:

--- a/test/git/data/global.yaml
+++ b/test/git/data/global.yaml
@@ -2,9 +2,10 @@ artifactRepoMap:
   default:
     host: index.docker.io
 
-buildVersionsRepo:
-  gitConnectionKey: local
-  path: build-versions.git
+buildVersions:
+  gitRepo:
+    gitConnectionKey: local
+    path: build-versions.git
 
 environmentMap:
   nonprod:

--- a/test/git/git.test.ts
+++ b/test/git/git.test.ts
@@ -10,8 +10,8 @@ describe('git:repo', async () => {
     if (gitConfig) {
       gitConfig.pathPrefix = path.join(__dirname, 'data', 'repos')
     }
-    if (!global.buildVersionsRepo) {
-      throw new Error('buildVersionsRepo must be set')
+    if (!global.buildVersions?.gitRepo) {
+      throw new Error('buildVersions.gitRepo must be set')
     }
 
     // clone


### PR DESCRIPTION
change global config:

```
buildVersionsRepo:
```

to:

```
buildVersions:
  gitRepo:
```

This will allow for future extensibility, for example if we wanted to support a KV store instead of a gitRepo the user could specify:

```
buildVersions:
  kvStore:
```

Also cleans up some unused interfaces in the spec